### PR TITLE
Fixing Vulnerable Vite Version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3231,8 +3231,8 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
       "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
Updating package lock for vite from vulnerable 6.2.4 to patched 6.2.6